### PR TITLE
Fixed Bug: called the refreshdataworker class by its name

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="BintrayJCenter" />
+      <option name="name" value="BintrayJCenter" />
+      <option name="url" value="https://jcenter.bintray.com/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven" />
+      <option name="name" value="maven" />
+      <option name="url" value="https://jitpack.io" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="Google" />
+      <option name="name" value="Google" />
+      <option name="url" value="https://dl.google.com/dl/android/maven2/" />
+    </remote-repository>
+  </component>
+</project>

--- a/app/src/main/java/com/android/movie/MovieApplication.kt
+++ b/app/src/main/java/com/android/movie/MovieApplication.kt
@@ -43,23 +43,21 @@ class MovieApplication : DaggerApplication() {
             .setConstraints(constraints)
             .build()
 
+        WorkManager.getInstance(this).enqueueUniquePeriodicWork(
+            WORKER_NAME,
+            ExistingPeriodicWorkPolicy.REPLACE,
+            repeatingRequest
+        )
+    }
 
+    override fun onCreate() {
+        super.onCreate()
         WorkManager.initialize(
             this,
             Configuration.Builder()
                 .setWorkerFactory(myWorkerFactory)
                 .build()
         )
-
-
-        WorkManager.getInstance(this).enqueueUniquePeriodicWork(
-            WORKER_NAME,
-            ExistingPeriodicWorkPolicy.REPLACE,
-            repeatingRequest)
-    }
-
-    override fun onCreate() {
-        super.onCreate()
         if (BuildConfig.DEBUG) {
             Timber.plant(Timber.DebugTree())
         }

--- a/app/src/main/java/com/android/movie/work/WorkerFactory.kt
+++ b/app/src/main/java/com/android/movie/work/WorkerFactory.kt
@@ -16,7 +16,9 @@ class MyWorkerFactory @Inject constructor(
         workerParameters: WorkerParameters
     ): ListenableWorker? {
         val foundEntry =
-            workerFactories.entries.find { Class.forName(workerClassName).isAssignableFrom(it.key) }
+            workerFactories.entries.find {
+                Class.forName(RefreshDataWorker::class.java.name).isAssignableFrom(it.key)
+            }
         val factoryProvider = foundEntry?.value
             ?: throw IllegalArgumentException("unknown worker class name: $workerClassName")
         return factoryProvider.get().create(appContext, workerParameters)


### PR DESCRIPTION
used RefreshDataWorker::class.java.name in the Worker Factory to avoid IllegalArgumentException